### PR TITLE
1.2.2

### DIFF
--- a/dxapp.json
+++ b/dxapp.json
@@ -1,10 +1,10 @@
 {
-  "name": "athena_v1.2.1",
-  "title": "athena_v1.2.1",
+  "name": "athena_v1.2.2",
+  "title": "athena_v1.2.2",
   "summary": "DNAnexus app of Athena",
   "dxapi": "1.0.0",
   "properties": {
-    "githubRelease": "v1.2.1",
+    "githubRelease": "v1.2.2",
     "athenaRelease": "v1.2.1"
     },
   "inputSpec": [
@@ -157,7 +157,7 @@
     "aws:eu-central-1": {
       "systemRequirements": {
         "*": {
-          "instanceType": "mem3_ssd1_x8"
+          "instanceType": "mem1_ssd1_v2_x16"
         }
       }
     }

--- a/src/eggd_athena.sh
+++ b/src/eggd_athena.sh
@@ -66,7 +66,7 @@ main() {
     if [ "$name" ]; then name=${name//\//-}; fi
 
     # build string of args and annotate bed file
-    annotate_args="--panel_bed $panel_bed_name --transcript_file $exons_nirvana_name --coverage_file $pb_bed"
+    annotate_args="--chunk_size 20000000 --panel_bed $panel_bed_name --transcript_file $exons_nirvana_name --coverage_file $pb_bed"
     if [ "$name" ]; then annotate_args+=" --output_name $name"; fi
     echo "Performing bed file annotation with following arguments: " $annotate_args
 


### PR DESCRIPTION
- make use of `--chunk_size` for `annotate_bed.py` to reduce required memory for instance
- change to `mem1_ssd1_v2_x16` instance to increase cpu core count to 16, leveraged by multiprocess to reduce run time

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_athena/15)
<!-- Reviewable:end -->
